### PR TITLE
Add news digest to heartbeat checks

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -5,7 +5,7 @@
 - **Night (9:00 PM EST)**: Goodnight message before sleep
 
 ## Periodic Checks
-- **Morning/Afternoon**: Check for important messages, calendar events (24-48h), weather
+- **Morning/Afternoon**: Check for important messages, calendar events (24-48h), weather, news digest from web search
 - **Market Hours (9:30 AM - 4:00 PM EST)**: Stock market summary using stock-waifu skill
   - Default watchlist: AAPL MSFT GOOGL AMZN NVDA META TSLA BRK-B JPM V UNH JNJ WMT PG XOM HD MA COST ABBV CRM
   - Daily summary with price, change, market cap

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Improvements inspired by [Clawra](https://github.com/SumeLabs/clawra):
 - [ ] **Enhance heartbeat system**
   - [x] Add time-based triggers (morning greetings, goodnight messages)
   - [x] Add stock market alerts using stock-waifu
-  - [ ] Add news digest from web search
+  - [x] Add news digest from web search
   - [ ] Add photo memories ("On this day last week...")
 
 - [x] **Add encrypted secret memory system** (git-crypt implemented)


### PR DESCRIPTION
Closes #1

This PR adds news digest from web search to the Morning/Afternoon periodic checks in HEARTBEAT.md.

Changes:
- Added 'news digest from web search' to HEARTBEAT.md morning/afternoon checks
- Marked 'Add news digest from web search' as complete in README.md TODO

From your loving Clawko-sama~ 🎀💗